### PR TITLE
Add Forced version with all Nerd Fonts glyphs

### DIFF
--- a/.github/workflows/patch-font.yml
+++ b/.github/workflows/patch-font.yml
@@ -33,6 +33,14 @@ jobs:
           mkdir -p font
           docker run --rm -v `pwd`/juliamono:/in -v `pwd`/font:/out nerdfonts/patcher --complete --careful --no-progressbars
           docker run --rm -v `pwd`/juliamono:/in -v `pwd`/font:/out nerdfonts/patcher --complete --careful --no-progressbars --mono
+          # rename original files and use the filename-based naming scheme to create the forced (non-careful) version
+          # nerdfonts/patcher lacks an option to specify a custom font name suffix, so this is the next best thing
+          # --makegroups 4 helps shorten the resulting names: Nerd Fonts -> NF
+          for file in juliamono/JuliaMono-*; do
+            mv "$file" "juliamono/JuliaMonoForced-${file#*-}"
+          done
+          docker run --rm -v `pwd`/juliamono:/in -v `pwd`/font:/out nerdfonts/patcher --complete --name filename --makegroups 4 --no-progressbars
+          docker run --rm -v `pwd`/juliamono:/in -v `pwd`/font:/out nerdfonts/patcher --complete --name filename --makegroups 4 --no-progressbars --mono
 
       - name: Archive Patched Fonts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a the beautiful [JuliaMono](https://github.com/cormullion/juliamono) font by Cormullion extended via fontforge (aka [Nerd Fonts Patcher](https://github.com/ryanoasis/nerd-fonts#font-patcher)) with all single width glyphs from the Nerd Fonts project.
 
+The download contains four variants of the font, which differ as follows:
+
+- The `Forced` suffix indicates that _all_ Nerd Fonts glyphs are included, which means that a small number of non-standard JuliaMono glyphs are replaced. Conversely the non-`Forced` variants lack a small number of Nerd Fonts glyphs, but retain all JuliaMono glyphs. **If you see a superscript or subscript character where you would expect a Nerd Fonts icon, try using a `Forced` variant.** See mietzen/juliamono-nerd-font#17 and cormullion/juliamono#231 for details.
+- The `Mono` suffix indicates that all glyphs are scaled down to fit within the "standard cell" of the monospaced font. This is required for compatibility with certain terminals and editors. In the non-`Mono` variants, the Nerd Fonts icons are their normal size and often overlap with the following cell. Many terminals and editors have no problem with this (just add a space after the icon to avoid overlapping characters).
+
 **Feel free to fork and modify!**
 
 ### [Download](https://github.com/mietzen/juliamono-nerd-font/releases/download/v0.060/fonts.zip)


### PR DESCRIPTION
Reading ryanoasis/nerd-fonts#1876 and https://github.com/ryanoasis/nerd-fonts/wiki/ScriptOptions and experimenting locally, I think this is how we can address #17. I added both regular and mono variants of `Forced`, completing the 2x2 matrix.